### PR TITLE
support custom target function

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ stylus --use stylus-css-modules --with "{dest:'./dest/script', target: 'ts'}" -w
   // string, base path for selector map script (default: same dir as the input .styl)
 
   target: 'ts',
-  // string, export format. 'ts' or 'js' (default: 'js')
+  // string, export format. 'ts' or 'js' (default: 'js'), can also be a function that receives the filename and selector map as params
 
   indent: 4,
   // number, indent level (default: 4)
@@ -40,6 +40,24 @@ stylus --use stylus-css-modules --with "{dest:'./dest/script', target: 'ts'}" -w
 }
 
 ```
+
+#### Defining a custom target
+
+If you need more control over the output, you can specify a `target` function like so:
+
+```js
+{
+    target(filename, selectorMap) {
+        // filename: /path/to/file.styl
+        // selectorMap: {
+        //   'file.styl': {
+        //      foo: '_123456789'
+        //    }
+        // }
+    }
+}
+```
+
 
 ## Result
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,19 +7,19 @@ var mkdirp = require('mkdirp');
 var camelCase = require('camelcase');
 
 /**
- * @param {object} option
+ * @param {object} pluginOptions
  * {
  *   dest: './src/scripts/styles/', // base path for selector map script.
- *   target: 'ts', // export format. 'ts' or 'js'
+ *   target: 'ts', // export format. 'ts' or 'js', can also be a function that receives the filename and selector map as params
  *   indent: 4, // indent level
  *   querySelector: false, // if true, prepend '.' as query selector
  *   projection: (id, originalClassName) => '_' + id, // mangle converter
  *   camelCase: true, // if true, convert selector name to camelCase. .text-center {} => {"textCenter": "_a"}
  * }
  */
-module.exports = function(option) {
+module.exports = function(pluginOptions) {
     return function(style) {
-        option = option || {};
+        pluginOptions = pluginOptions || {};
         style = this || style;
 
         style.options.sourcemap = {
@@ -27,46 +27,50 @@ module.exports = function(option) {
         };
         var srcDir = path.dirname(style.options.filename);
         var destDir = path.dirname(style.options.dest);
-        var scriptDir = option.dest || destDir;
-        var target = ({'ts':'ts','js':'js'})[option.target] || 'js';
+        var scriptDir = pluginOptions.dest || destDir;
+        var target = ({'ts':'ts','js':'js'})[pluginOptions.target] || 'js';
         var ts = target === 'ts';
-        var querySelector = !!option.querySelector;
-        var indent = typeof option.indent === 'number' ? option.indent : 4;
+        var querySelector = !!pluginOptions.querySelector;
+        var indent = typeof pluginOptions.indent === 'number' ? pluginOptions.indent : 4;
 
         style.on('end', function(err, css) {
             var sourceMap = sourceMapResolve.resolveSourceMapSync(css, null, fs.readFile);
             var mangled = mangle(css, sourceMap.map, {
-                camelCase: option.camelCase,
-                projection: option.projection
+                camelCase: pluginOptions.camelCase,
+                projection: pluginOptions.projection
             });
-            for (var i in mangled.map) {
-                var relativePath = path.relative(srcDir, path.resolve(destDir, i));
-                if (~relativePath.indexOf('..')) {
-                    console.log(color.yellow('Traversal path "' + relativePath + '" is not output.'));
-                    continue;
-                }
-                var styl = path.parse(relativePath);
-                var variableName = camelCase(styl.name);
-                var outputPath = path.resolve(scriptDir, relativePath.replace(new RegExp(styl.ext + '$'), '.' + target));
-                var source;
-                if (ts) {
-                    source = 'const ' + variableName + ' = ';
-                } else {
-                    source = 'module.exports = ';
-                }
-                var map = mangled.map[i];
-                if (querySelector) {
-                    for (var j in map) {
-                        map[j] = '.' + map[j];
+            if (typeof pluginOptions.target === 'function') {
+                pluginOptions.target(style.options.filename, mangled.map);
+            } else {
+                for (var i in mangled.map) {
+                    var relativePath = path.relative(srcDir, path.resolve(destDir, i));
+                    if (~relativePath.indexOf('..')) {
+                        console.log(color.yellow('Traversal path "' + relativePath + '" is not output.'));
+                        continue;
                     }
-                }
-                source += JSON.stringify(map, null, indent) + ";\n";
-                if (ts) {
-                    source += 'export {' + variableName + "};\n";
-                }
-                if (!fs.existsSync(outputPath) || fs.readFileSync(outputPath).toString('utf8') !== source) {
-                    mkdirp.sync(path.dirname(outputPath));
-                    fs.writeFileSync(outputPath, source);
+                    var styl = path.parse(relativePath);
+                    var variableName = camelCase(styl.name);
+                    var outputPath = path.resolve(scriptDir, relativePath.replace(new RegExp(styl.ext + '$'), '.' + target));
+                    var source;
+                    if (ts) {
+                        source = 'const ' + variableName + ' = ';
+                    } else {
+                        source = 'module.exports = ';
+                    }
+                    var map = mangled.map[i];
+                    if (querySelector) {
+                        for (var j in map) {
+                            map[j] = '.' + map[j];
+                        }
+                    }
+                    source += JSON.stringify(map, null, indent) + ";\n";
+                    if (ts) {
+                        source += 'export {' + variableName + "};\n";
+                    }
+                    if (!fs.existsSync(outputPath) || fs.readFileSync(outputPath).toString('utf8') !== source) {
+                        mkdirp.sync(path.dirname(outputPath));
+                        fs.writeFileSync(outputPath, source);
+                    }
                 }
             }
             return mangled.css;


### PR DESCRIPTION
Adds the ability to specify a function as the target, rather than just `ts | js` so the consumer can do custom things if they'd like.

In my case I'd like to customize the filename/location and template of the selector map.